### PR TITLE
devide main into botgo

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -1,0 +1,61 @@
+package albumbot
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/joho/godotenv"
+)
+
+func New() {
+	discordToken := "Bot " + loadToken()
+
+	session, err := discordgo.New()
+	if err != nil {
+		fmt.Println("Error in create session")
+		panic(err)
+	}
+	session.Token = discordToken
+	session.AddHandler(onMessageCreate)
+
+	if err = session.Open(); err != nil {
+		panic(err)
+	}
+	defer session.Close()
+
+	sc := make(chan os.Signal, 1)
+	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
+
+	fmt.Println("booted!!!")
+
+	<-sc
+	return
+}
+func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
+	if m.Author.ID == s.State.User.ID {
+		return
+	}
+
+	if m.Content == "!Hello" {
+		s.ChannelMessageSend(m.ChannelID, "Hello")
+	}
+
+	/*if strings.Contains(m.Content, "title:") && strings.Contains(m.Content, "urls:") {
+		var tmp = m.ContentWithMentionsReplaced()
+	}*/
+}
+
+func loadToken() string {
+	err := godotenv.Load()
+	if err != nil {
+		fmt.Printf("cannot load envrionments: %v", err)
+	}
+	token := os.Getenv("DISCORD_TOKEN")
+	if token == "" {
+		panic("no discord token exists.")
+	}
+	return token
+}

--- a/cmd/albumbot/main.go
+++ b/cmd/albumbot/main.go
@@ -1,63 +1,9 @@
 package main
 
 import (
-	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
-
-	"github.com/bwmarrin/discordgo"
-	"github.com/joho/godotenv"
+	"albumbot"
 )
 
 func main() {
-
-	discordToken := "Bot " + loadToken()
-
-	session, err := discordgo.New()
-	if err != nil {
-		fmt.Println("Error in create session")
-		panic(err)
-	}
-	session.Token = discordToken
-	session.AddHandler(onMessageCreate)
-
-	if err = session.Open(); err != nil {
-		panic(err)
-	}
-	defer session.Close()
-
-	sc := make(chan os.Signal, 1)
-	signal.Notify(sc, syscall.SIGINT, syscall.SIGTERM, os.Interrupt, os.Kill)
-
-	fmt.Println("booted!!!")
-
-	<-sc
-	return
-}
-
-func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
-	if m.Author.ID == s.State.User.ID {
-		return
-	}
-
-	if m.Content == "!Hello" {
-		s.ChannelMessageSend(m.ChannelID, "Hello")
-	}
-
-	/*if strings.Contains(m.Content, "title:") && strings.Contains(m.Content, "urls:") {
-		var tmp = m.ContentWithMentionsReplaced()
-	}*/
-}
-
-func loadToken() string {
-	err := godotenv.Load()
-	if err != nil {
-		fmt.Printf("cannot load envrionments: %v", err)
-	}
-	token := os.Getenv("DISCORD_TOKEN")
-	if token == "" {
-		panic("no discord token exists.")
-	}
-	return token
+	albumbot.New()
 }


### PR DESCRIPTION
main.goの内容をbot.goに移動させました。
今はbot.goのNew関数を呼び出すだけの状態になってます。

変更内容：
bot.goをalbumbotパッケージに属させて（プロジェクト直下において）、mainからNew関数を呼び出す。
複数のチャンネルで動くようにするにはbot型のインスタンス生成するようにしてって流れだと思うけど、少し不安だったのでとりあえず動いたものを提出。

動作検証：
.envファイルはmain.goと同じ階層でないと見つけられないので注意。bot.goと同じ階層に配置するとダメ。