### PR TITLE
データセットのパスを変える

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # albumbot
 
-### botの起動方法（ローカル版）
-・事前準備
+## botの起動方法（ローカル版）
+
+### 事前準備
+
 .envをmain.goと同じ階層に配置する。.envの書きぶりは以下参考リンク
 https://discordapp.com/channels/252122237761486849/788388972825018368/891657884570619934
 
-・起動コマンド
-$ go run main.go  
--booted!が出たら成功
+### 起動コマンド
+
+```sh
+go run ./cmd/albumbot/main.go  
+```
+
+booted!が出たら成功

--- a/album.go
+++ b/album.go
@@ -7,6 +7,8 @@ import (
 	"os"
 )
 
+const dataPath = "dataSet.json"
+
 // Albumはタイトルとそれに紐付けられた画像URLの集合です。
 type Album struct {
 	Title string
@@ -20,7 +22,7 @@ type Albums struct {
 
 // GetAlbumUrlsは与えられたアルバム名の画像のURLのリストを返します。
 func GetAlbumUrls(title string) (urls []string, e error) {
-	raw, err := ioutil.ReadFile("dataSet.json")
+	raw, err := ioutil.ReadFile(dataPath)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +72,7 @@ func GetAlbumPage(title string, start, count int) (urls []string, e error) {
 // PostAlbumUrlは与えられたアルバム名のUrl配列に与えられたUrlを追加します
 // ファイル全部読んで全部上書きする脳筋処理なので改良の余地ありです。。
 func PostAlbumUrl(albumTitle, url string) (e error) {
-	raw, err := ioutil.ReadFile("./dataSet.json")
+	raw, err := ioutil.ReadFile(dataPath)
 	if err != nil {
 		return err
 	}
@@ -86,7 +88,7 @@ func PostAlbumUrl(albumTitle, url string) (e error) {
 		if err != nil {
 			return err
 		}
-		writeError := ioutil.WriteFile("dataSet.json", marshaled, os.ModePerm)
+		writeError := ioutil.WriteFile(dataPath, marshaled, os.ModePerm)
 		if writeError != nil {
 			return writeError
 		}

--- a/album_test.go
+++ b/album_test.go
@@ -7,11 +7,8 @@ import (
 
 func TestGetAlbumUrls(t *testing.T) {
 	wants := []string{
-		"https://cdn.discordapp.com/attachments/723903982745157723/747799894001189024/00100lPORTRAIT_00100_BURST20190525180748800_COVER.jpg",
-		"https://cdn.discordapp.com/attachments/723903982745157723/782582360688033842/image0.jpg",
-		"https://cdn.discordapp.com/attachments/723903982745157723/784664833860960266/PXL_20201128_013520140.jpg",
-		"https://cdn.discordapp.com/attachments/723903982745157723/788395055843901450/image0.jpg",
-		"https://cdn.discordapp.com/attachments/723903982745157723/853546288527441940/unknown.png",
+		"https://test1.png",
+		"https://test2.png",
 	}
 	type args struct {
 		title string
@@ -23,13 +20,17 @@ func TestGetAlbumUrls(t *testing.T) {
 	}{{
 		name: "test",
 		args: args{
-			title: "taisho",
+			title: "test",
 		},
 		want: wants,
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got, _ := GetAlbumUrls(tt.args.title); !reflect.DeepEqual(got, tt.want) {
+			got, err := GetAlbumUrls(tt.args.title)
+			if err != nil {
+				panic(err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("GetAlbumUrls() = %v, want %v", got, tt.want)
 			}
 		})

--- a/dataSet.json
+++ b/dataSet.json
@@ -22,6 +22,13 @@
     {
       "title": "blank",
       "urls": []
+    },
+    {
+      "title": "test",
+      "urls": [
+        "https://test1.png",
+        "https://test2.png"
+      ]
     }
   ]
 }


### PR DESCRIPTION
最初は

```
	ep, err := os.Executable()
	if err != nil {
		return nil, err
	}
	dir := filepath.Dir(ep)
	dataPath := filepath.Join(dir, "dataSet.json")
```

でgoファイルの位置から `dataSet.json` のpathを得ようとしてたんですが、これだと `go build` だとうまくいくものの、 `go run` や `go test` だとgoファイルがtmpディレクトリに飛ばされて実行されるためにpathの解決がうまくいきませんでした。

なので諦めて、go runをリポジトリのルートから実行するようにREADMEを更新しました。