### PR TITLE
add options for general purpose

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -72,7 +72,7 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
 		} else {
 			for i := 0; i < 9; i++ {
-				s.MessageReactionAdd(m.ChannelID, m.ID, titles[i])
+				s.ChannelMessageSend(m.ChannelID, strconv.Itoa(i+1)+"."+titles[i])
 			}
 			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
 		}

--- a/bot.go
+++ b/bot.go
@@ -41,8 +41,8 @@ func getNumOptions() []string {
 	return arr
 }
 func containAtIndexNum(s []string, e string) (int, bool) {
-	for i := 0; i < len(s); i++ {
-		if e == s[i] {
+	for i, v := range s {
+		if e == v {
 			return i, true
 		}
 	}

--- a/bot.go
+++ b/bot.go
@@ -52,7 +52,7 @@ func getNumEmoji(i int) string {
 	if i > 9 {
 		return strconv.Itoa(i)
 	}
-	arr := []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"}
+	arr := getNumOptions()
 	return arr[i-1]
 }
 

--- a/bot.go
+++ b/bot.go
@@ -36,18 +36,37 @@ func New() {
 	<-sc
 	return
 }
+
+//getter関数を定義
 func getNumOptions() []string {
 	arr := []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"}
 	return arr
 }
-func containAtIndexNum(s []string, e string) (int, bool) {
-	for i, v := range s {
-		if e == v {
+
+//数字から数字スタンプ文字列を返す
+func getNumEmoji(i int) string {
+	if i < 1 {
+		return "❓"
+	}
+	// 対応する絵文字がない場合はその値をそのまま返す
+	if i > 9 {
+		return strconv.Itoa(i)
+	}
+	arr := []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"}
+	return arr[i-1]
+}
+
+//数字スタンプ文字列から数値とbool値を返す
+func getNumFromNumEmoji(s string) (int, bool) {
+	arr := getNumOptions()
+	for i := range s {
+		if s == arr[i] {
 			return i, true
 		}
 	}
 	return 0, false
 }
+
 func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if m.Content == "!Hello" {
@@ -79,18 +98,17 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 	}
 
 	if m.Content == "番号を選んでね！" && m.Author.ID == s.State.User.ID {
-		options := getNumOptions()
 		titles, err := GetAlbumTitles()
 		if err != nil {
 			panic(err)
 		}
 		if len(titles) <= 9 {
 			for i := 0; i < len(titles); i++ {
-				s.MessageReactionAdd(m.ChannelID, m.ID, options[i])
+				s.MessageReactionAdd(m.ChannelID, m.ID, getNumEmoji(i+1))
 			}
 		} else {
 			for i := 0; i < 9; i++ {
-				s.MessageReactionAdd(m.ChannelID, m.ID, options[i])
+				s.MessageReactionAdd(m.ChannelID, m.ID, getNumEmoji(i+1))
 			}
 			s.MessageReactionAdd(m.ChannelID, m.ID, "➡️")
 		}
@@ -109,8 +127,8 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 		} else if r.MessageReaction.Emoji.Name == "⬅️" { //アルバムのページを戻す操作予定
 
 		}
-		options := getNumOptions()
-		index, flag := containAtIndexNum(options, r.MessageReaction.Emoji.Name)
+
+		index, flag := getNumFromNumEmoji(r.MessageReaction.Emoji.Name)
 		if flag {
 			urls, err := GetAlbumUrls(titles[index])
 			if err != nil {

--- a/bot.go
+++ b/bot.go
@@ -36,6 +36,18 @@ func New() {
 	<-sc
 	return
 }
+func getNumOptions() []string {
+	arr := []string{"1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"}
+	return arr
+}
+func containAtIndexNum(s []string, e string) (int, bool) {
+	for i := 0; i < len(s); i++ {
+		if e == s[i] {
+			return i, true
+		}
+	}
+	return 0, false
+}
 func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 
 	if m.Content == "!Hello" {
@@ -53,15 +65,35 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		if err != nil {
 			panic(err)
 		}
-		for i, v := range titles {
-			s.ChannelMessageSend(m.ChannelID, strconv.Itoa(i)+"."+v)
+		if len(titles) <= 9 {
+			for i, v := range titles {
+				s.ChannelMessageSend(m.ChannelID, strconv.Itoa(i+1)+"."+v)
+			}
+			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
+		} else {
+			for i := 0; i < 9; i++ {
+				s.MessageReactionAdd(m.ChannelID, m.ID, titles[i])
+			}
+			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
 		}
-		s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
 	}
 
 	if m.Content == "番号を選んでね！" && m.Author.ID == s.State.User.ID {
-		s.MessageReactionAdd(m.ChannelID, m.ID, "1️⃣")
-		s.MessageReactionAdd(m.ChannelID, m.ID, "2️⃣")
+		options := getNumOptions()
+		titles, err := GetAlbumTitles()
+		if err != nil {
+			panic(err)
+		}
+		if len(titles) <= 9 {
+			for i := 0; i < len(titles); i++ {
+				s.MessageReactionAdd(m.ChannelID, m.ID, options[i])
+			}
+		} else {
+			for i := 0; i < 9; i++ {
+				s.MessageReactionAdd(m.ChannelID, m.ID, options[i])
+			}
+			s.MessageReactionAdd(m.ChannelID, m.ID, "➡️")
+		}
 	}
 
 }
@@ -71,15 +103,27 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 	if err != nil {
 		panic(err)
 	}
-	if r.UserID != s.State.User.ID && r.MessageReaction.Emoji.Name == "1️⃣" {
-		urls, err := GetAlbumUrls(titles[0])
-		if err != nil {
-			panic(err)
+	if r.UserID != s.State.User.ID {
+		if r.MessageReaction.Emoji.Name == "➡️" { //アルバムのページを進める操作
+
+		} else if r.MessageReaction.Emoji.Name == "⬅️" { //アルバムのページを戻す操作
+
 		}
-		for _, url := range urls {
-			s.ChannelMessageSend(r.ChannelID, url)
+		options := getNumOptions()
+		index, flag := containAtIndexNum(options, r.MessageReaction.Emoji.Name)
+		if flag {
+			urls, err := GetAlbumUrls(titles[index])
+			if err != nil {
+				panic(err)
+			}
+			for _, url := range urls {
+				s.ChannelMessageSend(r.ChannelID, url)
+			}
+			s.ChannelMessageSend(r.ChannelID, r.MessageReaction.Emoji.ID)
+			flag = false
 		}
-		s.ChannelMessageSend(r.ChannelID, r.MessageReaction.Emoji.ID)
+	} else {
+
 	}
 
 }

--- a/bot.go
+++ b/bot.go
@@ -104,9 +104,9 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 		panic(err)
 	}
 	if r.UserID != s.State.User.ID {
-		if r.MessageReaction.Emoji.Name == "➡️" { //アルバムのページを進める操作
+		if r.MessageReaction.Emoji.Name == "➡️" { //アルバムのページを進める操作予定
 
-		} else if r.MessageReaction.Emoji.Name == "⬅️" { //アルバムのページを戻す操作
+		} else if r.MessageReaction.Emoji.Name == "⬅️" { //アルバムのページを戻す操作予定
 
 		}
 		options := getNumOptions()


### PR DESCRIPTION
アルバム群をもとに、スタンプのリアクションで該当インデックスのアルバムを一覧で表示する、ということろまで汚いなりに実装。
動かすと表示が遅いので、多分どこかで高速化を図ったほうがいいです。
あとはダサいですが現状思いつかなかったので、１～９のスタンプ用の文字列のリストを作成しております。

「9タイトル以上のアルバムがあるときのページ遷移の具体的な挙動」
「一回リアクションしたときに他のリアクションに反応しないようにする」
については認識合わせの後時間があるときにissue立てときます。
