### PR TITLE
ページネーション機能

### DIFF
--- a/bot.go
+++ b/bot.go
@@ -271,14 +271,12 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 				for i := 0; i+5*pageindex < len(urls); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左の矢印スタンプでページ遷移します "+tmpurl)
 			} else {
 				for i := 0; i+5*pageindex < 5*(pageindex+1); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 			}
@@ -295,14 +293,12 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 				for i := 0; i < 5; i++ {
 					tmpurl += " " + urls[i]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "右の矢印スタンプでページ遷移します "+tmpurl)
 			} else {
 				for i := 0; i+5*pageindex < len(urls); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 			}
@@ -319,14 +315,12 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 				for i := 0; i+5*pageindex < len(urls); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左の矢印スタンプでページ遷移します "+tmpurl)
 			} else {
 				for i := 0; i+5*pageindex < 5*(pageindex+1); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 			}
@@ -340,14 +334,12 @@ func onReactionAdd(s *discordgo.Session, r *discordgo.MessageReactionAdd) {
 				for i := 0; i < 5; i++ {
 					tmpurl += " " + urls[i]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "右の矢印スタンプでページ遷移します "+tmpurl)
 			} else {
 				for i := 0; i+5*pageindex < len(urls); i++ {
 					tmpurl += " " + urls[i+5*pageindex]
 				}
-				//s.ChannelMessageEdit(r.ChannelID, message.ID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 				s.ChannelMessageDelete(r.ChannelID, r.MessageID)
 				s.ChannelMessageSend(r.ChannelID, "左右の矢印スタンプでページ遷移します "+tmpurl)
 			}

--- a/bot.go
+++ b/bot.go
@@ -14,7 +14,6 @@ import (
 //自分のbotを使用する場合はココを変更
 var callCommand = "!album"
 
-// New()の中で上書きされる可能性がある
 var titleindex = 0 //titleのindexを保持
 var pageindex = 0  //ページのindexを保持
 

--- a/bot.go
+++ b/bot.go
@@ -163,7 +163,7 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				if i >= 9 {
 					break
 				}
-			}		
+			}
 			s.ChannelMessageSend(m.ChannelID, tmpstr)
 			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
 		}

--- a/bot.go
+++ b/bot.go
@@ -158,17 +158,14 @@ func onMessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		}
 		if len(titles) <= 10 {
 			for i, v := range titles {
+				s.ChannelMessageSend(m.ChannelID, getNumEmoji(i+1)+" "+v)
 				tmpstr += getNumEmoji(i+1) + " " + v + "\n"
-			}
+				if i >= 9 {
+					break
+				}
+			}		
 			s.ChannelMessageSend(m.ChannelID, tmpstr)
 			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
-		} else {
-			for i := 0; i < 10; i++ {
-				tmpstr += getNumEmoji(i+1) + " " + titles[i] + "\n"
-			}
-			s.ChannelMessageSend(m.ChannelID, tmpstr)
-			s.ChannelMessageSend(m.ChannelID, "番号を選んでね！")
-			s.ChannelMessageEdit(m.ChannelID, m.ID, "番号を選んでね！")
 		}
 	}
 


### PR DESCRIPTION
画像を5枚ずつ表示して左右スタンプで遷移する。
(taishoアルバムで実験を行った、8枚および13枚の写真で想定の動作を検証)

titleindexとpageindexはグローバル変数でもってて!album呼び出し時に初期化を行う仕組み。

あとスピードアップのために数字スタンプ＋タイトルの出力の部分をまとめて処理したら少し動作が早くなったと思われる。

遷移はメッセージの削除と新規作成を繰り返して実装している。遷移の条件はメッセージ冒頭の「＊の矢印で遷移します」に依存しており、押下されたスタンプによって遷移の挙動を行う。